### PR TITLE
Add new Italian translation

### DIFF
--- a/app/it.lproj/LicensingInfo.html
+++ b/app/it.lproj/LicensingInfo.html
@@ -1,0 +1,19 @@
+<style>
+  html{font-family:'Lucida Grande',arial;font-size:10px;cursor:default;color:#666;}
+  html,body {overflow: hidden;}
+  a,a:visited{color:#66f;}
+  a:hover{color:#22f}
+  h1{white-space:nowrap;}
+  ul{margin:0;padding:0;padding-left:16px;}
+  p{margin-bottom: 10px}
+  .choice{margin-top: 6px;}
+  .example{margin-left: 14px;margin-top: 2px; font-size: 9px;}
+  .note {font-size: 9px;}
+  </style>
+
+<p>Puoi usare la tua licenza in due modi:</p>
+<div class="choice">1. <strong>un utente su più computer</strong> <span class="note">(se sei l'unico utente ad usare TotalSpaces2)</span></div>
+<div class="example">Esempio: un computer fisso ed un portatile utilizzati esclusivamente da te</div>
+<div class="choice">2. <strong>più utenti su un singolo computer</strong></div>
+<div class="example">Esempio: un computer casalingo condiviso dai membri di tutta la famiglia</div>
+<p class="note">Per maggiori informazioni sulla licenza si prega di visitare <a href="http://totalspaces.binaryage.com/licensing2">http://totalspaces.binaryage.com/licensing2</a></p>

--- a/app/it.lproj/Localizable.strings
+++ b/app/it.lproj/Localizable.strings
@@ -1,0 +1,384 @@
+/* Registration dialog */
+"Registration" = "Registrazione";
+
+/* Registration dialog */
+"Please enter your license details from the email we have sent you:" = "Per favore inserisci i dettagli della licenza dall'email che ti abbiamo inviato:";
+
+/* Registration dialog */
+"Register" = "Registrati";
+
+/* Registration dialog */
+"Buy TotalSpaces2 Now" = "Acquista adesso TotalSpaces2";
+
+/* Registration dialog */
+"Invalid license code" = "Codice di licenza non valido";
+
+/* Registration dialog */
+"Please go back and try again." = "Si prega di tornare indietro e riprovare.";
+
+/* Registration dialog */
+"To purchase a license for TotalSpaces2, please visit BinaryAge web store." = "Per acquistare una licenza di TotalSpaces2, visita il web store BinaryAge.";
+
+/* Registration dialog */
+"Back" = "Indietro";
+
+/* Registration dialog */
+"Thanks for registering!" = "Grazie per la registrazione!";
+
+/* Registration dialog */
+"This TotalSpaces2 copy is licensed to:" = "Copia di TotalSpaces2 concessa in licenza a:";
+
+/* Registration dialog */
+"Change License" = "Modifica licenza";
+
+/* Registration dialog */
+"Close" = "Chiudi";
+
+/* Registration dialog */
+"TotalSpaces2 Registration" = "Registrazione di TotalSpaces2";
+
+/* Registration dialog */
+"Licensed to" = "Concesso in licenza a";
+
+/* Registration dialog */
+"Thank you for using TotalSpaces2!" = "Grazie per l'utilizzo di TotalSpaces2!";
+
+/* Registration dialog */
+"Trial period finished - Please buy TotalSpaces2" = "Periodo di prova terminato - Per favore acquista TotalSpaces2";
+
+/* Registration dialog /*
+"Trial version" = "Versione di prova";
+
+/* Registration dialog - http://unicode.org/repos/cldr-tmp/trunk/diff/supplemental/language_plural_rules.html */
+"%d days left##{other}" = "%d giorni rimanenti";
+
+/* Registration dialog */
+"%d days left##{one}" = "%d giorni rimanenti";
+
+/* Registration dialog */
+"Buy now!" = "Acquista!";
+
+/* non grid desktop name for menu */
+"%@ (not in grid)" = "%@ (fuori griglia)";
+
+/* default numbered desktop name */
+"%ld (Desktop)" = "%ld (Desktop)";
+
+/* default fullscreen desktop name when fullscreen is in the grid */
+"%ld (Fullscreen)" = "%ld (Schermo intero)";
+
+/* default fullscreen desktop name when fullscreen is not in the grid */
+"(Fullscreen)" = "(Schermo intero)";
+
+/* 3 finger swipe dialog */
+"3 finger swiping" = "Sfiora con 3 dita";
+
+/* No comment provided by engineer. */
+"About" = "Informazioni";
+
+/* No comment provided by engineer. */
+"About (Unregistered)" = "Informazioni (Non registrato)";
+
+/* add/remove desktops button */
+"Add desktops" = "Aggiungi scrivania";
+
+/* Toolbar item name for the Advanced preference pane */
+"Advanced" = "Avanzate";
+
+/* Toolbar item name for the App Spaces preference pane */
+"Apps" = "Applicazioni";
+
+/* No comment provided by engineer. */
+"Check for updates" = "Controlla aggiornamenti";
+
+/* Toolbar item name for the Circulation preference pane */
+"Circulation" = "Scorrimento";
+
+/* dashboard name shown in menu */
+"Dashboard" = "Dashboard";
+
+/* Toolbar item name for the General preference pane */
+"General" = "Generale";
+
+/* Toolbar item name for the Hotcorners preference pane */
+"Hotcorners" = "Angoli attivi";
+
+/* Toolbar item name for the Hotkeys preference pane */
+"Hotkeys" = "Scorciatoie";
+
+/* Toolbar item name for the Layout preference pane */
+"Layout" = "Layout";
+
+/* 3 finger swipe dialog
+   hotkey cannot be assigned dialog */
+"OK" = "OK";
+
+/* Hotkey already in use dialog */
+"Cancel" = "Annulla";
+
+/* No comment provided by engineer. */
+"Overview grid" = "Griglia panoramica";
+
+/* 3 finger swipe dialog */
+"Please note that we recommend turning off Three finger drag in the Point & Click section of Trackpad preferences (in System Preferences), otherwise the actions may activate simultaneously" = "Si raccomanda di disabilitare Trascina con tre dita nel pannello Punta e fai clic delle impostazioni Trackpad (in Preferenze di Sistema), altrimenti le azioni possono attivarsi simultaneamente";
+
+/* hotkeys */
+"Please use a different combination, or check in keyboard preferences that it is not already assigned" = "Per favore utilizza una combinazione differente, o controla che non sia già stata assegnata nelle impostazioni Tastiera";
+
+/* Preferences window */
+"Preferences" = "Preferenze";
+
+/* No comment provided by engineer. */
+"Quit" = "Esci";
+
+/* add/remove desktops button */
+"Remove desktops" = "Rimuovi scrivanie";
+
+/* unshow menu bar dialog */
+"Menu bar item removal" = "Rimozione voce barra dei menu";
+
+/* hotkeys */
+"That key combination could not be assigned" = "Impossibile assegnare la combinazione di tasti";
+
+/* hotkeys */
+"That key combination is already in use" = "Combinazione di tasti già in uso";
+
+/* hotkeys */
+"The system rejected the assignment even though we tried to force it" = "Il sistema ha rifiutato l'assegnazione nonostante il tentativo di forzarla";
+
+/* unshow menu bar dialog */
+"To show the preferences, you can double-click the application in your Applications folder" = "Per mostrare le preferenze, puoi fare doppio clic sull'applicazione nella cartella Applicazioni";
+
+/* Toolbar item name for the Transitions preference pane */
+"Transitions" = "Transizioni";
+
+/* No comment provided by engineer. */
+"Trial period expired" = "Periodo di prova terminato";
+
+/* hotkey already in use dialog */
+"Use anyway" = "Usa comunque";
+
+/* layout desktop status label single */
+"You have %ld desktops##{one}" = "Hai %ld scrivania";
+
+/* layout desktop status label plural */
+"You have %ld desktops##{other}" = "Hai %ld scrivanie";
+
+/* layout desktop requirements label single */
+"You need %ld desktops##{one}" = "Vuoi %ld scrivania";
+
+/* layout desktop requirements label plural */
+"You need %ld desktops##{other}" = "Vuoi %ld scrivanie";
+
+/* Hotkeys prefs */
+"Change space" = "Cambia spazio";
+
+/* Hotkeys prefs */
+"Move current window" = "Sposta finestra corrente";
+
+/* Hotkeys prefs */
+"Arrow keys with" = "Tasti Freccia con";
+
+/* Hotkeys prefs */
+"Hotkey" = "Scorciatoia";
+
+/* Hotkeys prefs */
+"Mouse" = "Mouse";
+
+/* Hotkeys prefs */
+"Instant exposé" = "Exposé istantaneo";
+
+/* Hotkeys prefs */
+"Instant exposé mouse" = "Exposé istantaneo (mouse)";
+
+/* Hotkeys prefs */
+"Toggle exposé" = "Attiva exposé";
+
+/* Hotkeys prefs */
+"Space bar" = "Barra spaziatrice";
+
+/* Hotkeys prefs */
+"Use the space bar to toggle exposé when using the overview grid" = "Usa la barra spaziatrice per abilitare exposé mentre usi la griglia panoramica";
+
+/* Hotkeys prefs */
+"Choose button" = "Scegli tasto";
+
+/* Hotkeys prefs */
+"3rd/middle button" = "Pulsante centrale";
+
+/* Hotkeys prefs */
+"4th button" = "4° pulsante";
+
+/* Hotkeys prefs */
+"5th button" = "5° pulsante";
+
+/* Hotkeys prefs popover */
+"Left" = "Sinistra";
+
+/* Hotkeys prefs popover */
+"Right" = "Destra";
+
+/* Hotkeys prefs popover */
+"Up" = "Su";
+
+/* Hotkeys prefs popover */
+"Down" = "Giù";
+
+/* Hotkeys prefs popover */
+"Arrow keys" = "Tasti Freccia";
+
+/* Hotkeys prefs popover */
+"Custom" = "Personalizza";
+
+/* General prefs */
+"Start TotalSpaces2 at Login" = "Avvia TotalSpaces2 al Login";
+
+/* General prefs */
+"Show notification graphic on desktop change" = "Mostra notificha grafica al cambio di scrivania";
+
+/* General prefs */
+"Hide menu bar icon" = "Nascondi icona nella barra dei menu";
+
+/* General prefs */
+"Automatically check for updates" = "Controllo aggiornamenti automatico";
+
+/* General prefs */
+"Include pre-releases" = "Includi versioni preliminari";
+
+/* General prefs */
+"Zoom to overview grid animation" = "Animazione per zoom verso griglia panoramica";
+
+/* General prefs */
+"Desktop backgrounds in the overview grid" = "Sfondo griglia panoramica";
+
+/* General prefs grid backgrounds */
+"Hi res" = "Alta risoluzione";
+
+/* General prefs grid backgrounds */
+"Lo res" = "Bassa risoluzione";
+
+/* General prefs grid backgrounds */
+"None (fastest)" = "Nessuno (più veloce)";
+
+/* General prefs grid zoom */
+"Desktop zoom" = "Zoom scrivania";
+
+/* General prefs grid zoom */
+"Whole grid zoom" = "Zoom intera griglia";
+
+/* General prefs grid zoom */
+"None" = "Nessuna";
+
+/* Circulation prefs */
+"Enable circulation" = "Abilita scorrimento circolare";
+
+/* Circulation prefs */
+"Circulate vertically (join top row to bottom row)" = "Scorri verticalmente (unisci riga superiore alla riga inferiore)";
+
+/* Circulation prefs */
+"Right end of row joins to left end of:" = "Estremità destra della riga unita alla sinistra della:";
+
+/* Circulation prefs */
+"Next row" = "Riga successiva";
+
+/* Circulation prefs */
+"Same row" = "Stessa riga";
+
+/* App binding prefs */
+"Application" = "Applicazione";
+
+/* App binding prefs */
+"Desktop" = "Scrivania";
+
+/* App binding prefs */
+"Use this panel to assign apps to specific desktops" = "Usa questo pannello per assegnare applicazioni a scrivanie specifiche";
+
+/* App binding prefs */
+"All spaces" = "Tutti gli spazi";
+
+/* Transitions prefs */
+"Use transitions" = "Usa transizioni";
+
+/* Transitions prefs */
+"Animation" = "Animazione";
+
+/* Transitions prefs */
+"Slide" = "Scorrimento";
+
+/* Transitions prefs */
+"Cube" = "Cubo";
+
+/* Transitions prefs */
+"Flip" = "Ribaltamento";
+
+/* Transitions prefs */
+"Reveal" = "Svelamento";
+
+/* Transitions prefs */
+"Fade" = "Dissolvenza";
+
+/* Transitions prefs */
+"Inside cube" = "Cubo interno";
+
+/* Transitions prefs */
+"Speed" = "Velocità";
+
+/* Transitions prefs */
+"Slow" = "Lenta";
+
+/* Transitions prefs */
+"Fast" = "Veloce";
+
+/* Transitions prefs */
+"Swipe to change space" = "Cambia spazio, sfiora con";
+
+/* Transitions prefs */
+"3 fingers" = "3 dita";
+
+/* Transitions prefs */
+"4 fingers" = "4 dita";
+
+/* Transitions prefs */
+"5 fingers" = "5 dita";
+
+/* Transitions prefs */
+"Invert swipe direction" = "Inverti direzione sfioramento";
+
+/* Transitions prefs */
+"Change space by moving mouse to the edge of the screen" = "Cambia spazio muovendo il mouse all'angolo dello schermo";
+
+/* Transitions prefs */
+"With key" = "Premendo il tasto";
+
+/* Layout prefs - naming popup */
+"Name" = "Nome";
+
+/* Layout prefs - naming popup */
+"Done" = "Fatto";
+
+/* Layout prefs - naming popup */
+"Hotkey for position" = "Scorciatoia selezione";
+
+/* Layout prefs */
+"For this grid" = "Per questa griglia";
+
+/* Layout prefs */
+"Rows:" = "Righe:";
+
+/* Layout prefs */
+"Columns:" = "Colonne:";
+
+/* Layout prefs */
+"Select display" = "Seleziona monitor";
+
+
+/* Hotcorners prefs */
+"Show overview grid" = "Mostra griglia panoramica";
+
+/* Hotcorners prefs */
+"Exposé (when in grid)" = "Abilita exposé (nella griglia)";
+
+/* Hotcorners prefs */
+"Overview grid with exposé" = "Grglia panoramica con exposé";
+
+

--- a/uninstaller/English.lproj/Localizable.strings
+++ b/uninstaller/English.lproj/Localizable.strings
@@ -1,23 +1,23 @@
 /* buttons */
-"Quit" = "Esci";
-"Cancel" = "Annulla";
-"Uninstall" = "Disinstalla";
-"Details" = "Dettagli";
+"Quit" = "Quit";
+"Cancel" = "Cancel";
+"Uninstall" = "Uninstall";
+"Details" = "Details";
 
 /* tooltips */
-"Show detailed transcript" = "Mostra informazioni dettagliate";
+"Show detailed transcript" = "Show detailed transcript";
 
 /* main texts */
-"You are about uninstall *APP*" = "Stai per disinstallare TotalSpaces2";
-"This program will uninstall all *APP* components from this computer." = "Questo programma disinstallerà tutti i componenti di TotalSpaces2 dal computer.";
-"*APP* has been uninstalled" = "TotalSpaces2 è stato disinstallato";
-"Have a nice day." = "Buona giornata.";
-"*APP* uninstallation failed" = "Disinstallazione di TotalSpaces2 fallita";
-"The uninstall script encountered problems. Please see the details. Please report bugs to support@binaryage.com." = "Problemi con lo script di disinstallazione. Visionare i dettagli. Si prega di segnalare i bug a support@binaryage.com.";
+"You are about uninstall *APP*" = "You are about uninstall TotalSpaces2";
+"This program will uninstall all *APP* components from this computer." = "This program will uninstall all TotalSpaces2 components from this computer.";
+"*APP* has been uninstalled" = "TotalSpaces2 has been uninstalled";
+"Have a nice day." = "Have a nice day.";
+"*APP* uninstallation failed" = "TotalSpaces2 uninstallation failed";
+"The uninstall script encountered problems. Please see the details. Please report bugs to support@binaryage.com." = "The uninstall script encountered problems. Please see the details. Please report bugs to support@binaryage.com.";
 
 /* possible script messages in details section */
-"Uninstaller needs admin privileges to remove *APP* from your system." = "Per disinstallare TotalSpaces2 dal sistema sono necessari i privilegi di admministratore.";
-"Running uninstall script:\n" = "Esecuzione script disinstallazione:\n";
-"Uninstall script finished successfully.\n" = "Script disinstallazione completato con successo.\n";
-"Uninstall script needs admin rights.\n" = "Sono necessari i privilegi di amministrazione.\n";
-"Uninstall script failed with error [%d].\n" = "Script di disinstallazione fallito con errore [%d].\n";
+"Uninstaller needs admin privileges to remove *APP* from your system." = "Uninstaller needs admin privileges to remove TotalSpaces2 from your system.";
+"Running uninstall script:\n" = "Running uninstall script:\n";
+"Uninstall script finished successfully.\n" = "Uninstall script finished successfully.\n";
+"Uninstall script needs admin rights.\n" = "Uninstall script needs admin rights.\n";
+"Uninstall script failed with error [%d].\n" = "Uninstall script failed with error [%d].\n";

--- a/uninstaller/it.lproj/Localizable.strings
+++ b/uninstaller/it.lproj/Localizable.strings
@@ -1,0 +1,23 @@
+/* buttons */
+"Quit" = "Esci";
+"Cancel" = "Annulla";
+"Uninstall" = "Disinstalla";
+"Details" = "Dettagli";
+
+/* tooltips */
+"Show detailed transcript" = "Mostra informazioni dettagliate";
+
+/* main texts */
+"You are about uninstall *APP*" = "Stai per disinstallare TotalSpaces2";
+"This program will uninstall all *APP* components from this computer." = "Questo programma disinstallerà tutti i componenti di TotalSpaces2 dal computer.";
+"*APP* has been uninstalled" = "TotalSpaces2 è stato disinstallato";
+"Have a nice day." = "Buona giornata.";
+"*APP* uninstallation failed" = "Disinstallazione di TotalSpaces2 fallita";
+"The uninstall script encountered problems. Please see the details. Please report bugs to support@binaryage.com." = "Problemi con lo script di disinstallazione. Visionare i dettagli. Si prega di segnalare i bug a support@binaryage.com.";
+
+/* possible script messages in details section */
+"Uninstaller needs admin privileges to remove *APP* from your system." = "Per disinstallare TotalSpaces2 dal sistema sono necessari i privilegi di admministratore.";
+"Running uninstall script:\n" = "Esecuzione script disinstallazione:\n";
+"Uninstall script finished successfully.\n" = "Script disinstallazione completato con successo.\n";
+"Uninstall script needs admin rights.\n" = "Sono necessari i privilegi di amministrazione.\n";
+"Uninstall script failed with error [%d].\n" = "Script di disinstallazione fallito con errore [%d].\n";


### PR DESCRIPTION
Hey, I just finished to translate everything! :) :+1: 

I did my best to stay conform to the Apple.com website glossary, to find the best way to translate maintaining the meaning and not overflowing the fields spaces (nice UI design though!).

There is only one overflow problem in "_Preferences -> Hotkeys -> Change space + Custom_"

"_Left_" can just be translated with the longer "_Sinistra_".
I could shorten with the abbreviations "_Sx_" ("_Sinistra_" = Left) and "_Dx_" ("_Destra_" = Right), but is not so nice for the UX.

Would be wonderful if some few pixel of width could be added so the the word would not overflow.
Just update me on what you prefer!
